### PR TITLE
tasks/configure.yml - fix sysctl setting

### DIFF
--- a/tasks/configure.yml
+++ b/tasks/configure.yml
@@ -1,7 +1,7 @@
 ---
 - name: set max_user_namespaces
   sysctl:
-    name: max_user_namespaces
+    name: user.max_user_namespaces
     value: "{{ podman_max_user_namespaces }}"
     sysctl_set: true
     state: present

--- a/tasks/configure.yml
+++ b/tasks/configure.yml
@@ -18,5 +18,5 @@
 - name: create /etc/subgid
   copy:
     content: "{{ podman_user }}:{{ podman_subuid }}:{{ podman_subgid }}"
-    dest: /etc/subuid
+    dest: /etc/subgid
   become: true

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -4,9 +4,9 @@
 - name: assert supported distributions and versions
   assert:
     that:
-      - ( ansible_distribution == "RedHat" and ( ansible_distribution_version >= '7.8' )
+      - ( ansible_distribution == "RedHat" and ( ansible_distribution_version >= '7.7' )
         ) or
-        ( ansible_distribution == "CentOS" and ( ansible_distribution_version >= '7.8' )
+        ( ansible_distribution == "CentOS" and ( ansible_distribution_version >= '7.7' )
         ) or
         ( ansible_distribution == "Fedora" and ( ansible_distribution_major_version == "31" )
         ) or

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -4,9 +4,9 @@
 - name: assert supported distributions and versions
   assert:
     that:
-      - ( ansible_distribution == "RedHat" and ( ansible_distribution_major_version >= '7' )
+      - ( ansible_distribution == "RedHat" and ( ansible_distribution_version >= '7.8' )
         ) or
-        ( ansible_distribution == "CentOS" and ( ansible_distribution_major_version >= "7" )
+        ( ansible_distribution == "CentOS" and ( ansible_distribution_version >= '7.8' )
         ) or
         ( ansible_distribution == "Fedora" and ( ansible_distribution_major_version == "31" )
         ) or
@@ -14,6 +14,8 @@
         ) or
         ( ansible_distribution == "Ubuntu" and ( ansible_distribution_major_version == "18" )
         )
+    fail_msg: "Unsupported OS version: {{ ansible_os_family }} {{ ansible_distribution_version }}"
+
 
 - name: include os specific variables
   include_vars: "{{ item }}"


### PR DESCRIPTION
The sysctl parameter didn't exist and this caused the tasks/configure.yml to fail:

```
TASK [crivetimihai.podman : set max_user_namespaces] ***************************
[WARNING]: The value 10000 (type int) in a string field was converted to
u'10000' (type string). If this does not look like what you expect, quote the
entire value to ensure it does not change.
fatal: [podman-srv]: FAILED! => {"changed": false, "msg": "Failed to reload sysctl: sysctl: cannot stat /proc/sys/max_user_namespaces: No such file or directory\n"}
```

This PR fixes the sysctl setting.